### PR TITLE
feat: support ascending sort strategy

### DIFF
--- a/lua/telescope-undo/init.lua
+++ b/lua/telescope-undo/init.lua
@@ -132,6 +132,8 @@ M.undo = function(opts)
         finder = finders.new_table({
           results = build_undolist(),
           entry_maker = function(undo)
+            local order = require('telescope.config').values.sorting_strategy;
+
             -- TODO: show a table instead of a list
             if #undo.additions + #undo.deletions == 0 then
               -- skip empty changes, vim has these sometimes...
@@ -152,9 +154,10 @@ M.undo = function(opts)
             if undo.alt > 0 then
               prefix = string.rep("┆ ", undo.alt - 1)
               if undo.first then
-                prefix = prefix .. "└─"
+                local corner = order == 'ascending' and '┌' or '└'
+                prefix = prefix .. corner .. "╴"
               else
-                prefix = prefix .. "├─"
+                prefix = prefix .. "├╴"
               end
             end
             return {


### PR DESCRIPTION
Use the "down and right" character for corners when Telescope's sorting strategy is "ascending". Also use the "left" line character for the horizontal connector so there's a little space between the connector and the text.

<img width="330" alt="Screenshot 2022-12-22 at 12 13 00" src="https://user-images.githubusercontent.com/1042866/209189618-37bbbaa0-9c94-4cec-853c-7aca8cd840dd.png">
