### PR TITLE
actions: return the data acted upon

### DIFF
--- a/lua/telescope-undo/actions.lua
+++ b/lua/telescope-undo/actions.lua
@@ -42,6 +42,7 @@ myactions.yank_deletions = function(prompt_bufnr)
     if entry ~= nil then
       vim.fn.setreg(_get_default_register(), entry.value.deletions, (#entry.value.deletions > 1) and "V" or "v")
       actions.close(prompt_bufnr)
+      return entry.value.deletions
     end
   end
   return yank_deletions
@@ -54,6 +55,7 @@ myactions.yank_additions = function(prompt_bufnr)
     if entry ~= nil then
       vim.fn.setreg(_get_default_register(), entry.value.additions, (#entry.value.additions > 1) and "V" or "v")
       actions.close(prompt_bufnr)
+      return entry.value.additions
     end
   end
   return yank_additions


### PR DESCRIPTION
allows the user to use that information for further processing

the idea of this PR is to allow users to customize the effect of the builtin actions. Of course, without that, the user could copy-paste the actions in their config, but it seems like a waste.
Currently I'm using this to display myself notifications (using my own notification system), but it could be used for any post-processing.
With regards to my use (notifications) in theory you could call vim.notify(), although it personally wouldn't suit me. But with the way I suggest, it's up to the user, they can do whatever they want (although as I mentioned, already now they can copy-paste and modify your actions).

This is what I do, or would do if this gets merged:

```lua
              ["<C-r>a"] = function(prompt_bufnr)
                local base = require("telescope-undo.actions").yank_additions(prompt_bufnr)
                local function with_notif()
                    res = base()
                    notif({"Copied " .. #res .. " lines to the clipboard"})
                end
                return with_notif
              end,
              ["<C-r>d"] = function(prompt_bufnr)
                local base = require("telescope-undo.actions").yank_deletions(prompt_bufnr)
                local function with_notif()
                    res = base()
                    notif({"Copied " .. #res .. " lines to the clipboard"})
                end
                return with_notif
              end,
```