### PR TITLE
Allow users to disable default keymaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,22 @@ opts = {
 }
 ```
 
+If you wish to disable one of the default mappings, just set it to `false`.
+
+```lua
+opts = {
+  extensions = {
+    undo = {
+      mappings = {
+        i = {
+          ["<C-y>"] = false,
+        },
+      },
+    },
+  },
+}
+```
+
 ## Contributions
 
 Suggestions, issues and patches are very much welcome. There are some TODOs sprinkeled into the code

--- a/lua/telescope/_extensions/undo.lua
+++ b/lua/telescope/_extensions/undo.lua
@@ -43,6 +43,12 @@ end
 
 M.setup = function(extension_config, telescope_config)
   M.config = vim.tbl_deep_extend("force", defaults, extension_config)
+  -- Remove default keymaps that have been disabled by the user.
+  for _, mode in ipairs({ "i", "n" }) do
+    M.config.mappings[mode] = vim.tbl_map(function(val)
+      return val ~= false and val or nil
+    end, M.config.mappings[mode])
+  end
   if M.config["side_by_side"] and not M.config["use_delta"] then
     error("telescope_undo.nvim: setting side_by_side but not use_delta will have no effect")
   end


### PR DESCRIPTION
### Description

This PR is related to #47.

Some users may wish to disable one or more of Telescope-undo's default key mappings in favor of the defaults they defined for all Telescope pickers. This PR enables them to do so by setting the default mapping to `false`.

```lua
opts = {
  extensions = {
    undo = {
      mappings = {
        i = {
          ["<C-y>"] = false,
        },
      },
    },
  },
}
```

### Notes

We use `false` here rather than `nil` because setting a table value to `nil` in Lua is the same as deleting the value from the table. Disabling default key mappings by setting them to `false` is the convention used by several other Neovim plugins, including [lazy.nvim](https://github.com/folke/lazy.nvim).