### PR TITLE
fix: use correct "sorting_strategy" config attribute to render undo tree

### DIFF
--- a/lua/telescope-undo/init.lua
+++ b/lua/telescope-undo/init.lua
@@ -127,7 +127,7 @@ M.undo = function(opts)
       finder = finders.new_table({
         results = build_undolist(opts),
         entry_maker = function(undo)
-          local order = require("telescope.config").values.sorting_strategy
+          local order = opts.sorting_strategy or conf.sorting_strategy
 
           -- TODO: show a table instead of a list
           if #undo.additions + #undo.deletions == 0 then


### PR DESCRIPTION
Previously, when opposite "sorting_strategy" attributes were defined in telescope's and undo's configs, wrong corner char was chosen when rendering undo tree